### PR TITLE
Exclude VAADIN dir from scan list to avoid Jetty restart and 404 page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
-             
+
         <repository>
             <id>vaadin-prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
@@ -166,9 +166,19 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.22.v20191022</version>
+                <version>9.4.27.v20200227</version>
                 <configuration>
                     <scanIntervalSeconds>2</scanIntervalSeconds>
+                    <!--
+                        Exclude 'VAADIN' directory, and it's content from Jetty hot-swap
+                        scanner list to avoid Jetty restart while webpack is working
+                    -->
+                    <scanClassesPattern>
+                        <excludes>
+                            <exclude>${project.build.outputDirectory}/META-INF/VAADIN/**</exclude>
+                            <exclude>${project.build.outputDirectory}/META-INF/VAADIN</exclude>
+                        </excludes>
+                    </scanClassesPattern>
                     <!-- Use war output directory to get the webpack files -->
                     <webAppConfig>
                         <allowDuplicateFragmentNames>true</allowDuplicateFragmentNames>
@@ -227,7 +237,7 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>it</id>
             <build>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bookstore-example/69)
<!-- Reviewable:end -->
