### PR TITLE
Redirect to the Login page instead of error view

### DIFF
--- a/src/main/java/org/vaadin/example/bookstore/ui/ErrorView.java
+++ b/src/main/java/org/vaadin/example/bookstore/ui/ErrorView.java
@@ -8,6 +8,9 @@ import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.ParentLayout;
+import org.vaadin.example.bookstore.authentication.AccessControl;
+import org.vaadin.example.bookstore.authentication.AccessControlFactory;
+import org.vaadin.example.bookstore.ui.login.LoginScreen;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -29,6 +32,12 @@ public class ErrorView extends VerticalLayout implements HasErrorParameter<NotFo
 
     @Override
     public int setErrorParameter(BeforeEnterEvent event, ErrorParameter<NotFoundException> parameter) {
+        final AccessControl accessControl = AccessControlFactory
+                .getInstance().createAccessControl();
+        if (!accessControl.isUserSignedIn()) {
+            event.rerouteTo(LoginScreen.class);
+            return HttpServletResponse.SC_FORBIDDEN;
+        }
         explanation.setText("Could not navigate to '"
                 + event.getLocation().getPath() + "'.");
         return HttpServletResponse.SC_NOT_FOUND;


### PR DESCRIPTION
Redirect to the Login page instead of error view if user is not autenticated

Currently, if user is not authenticated and navigates to `http://localhost:8080/Admin/1` an error page, which reveals layout structure is shown. Moreover it reveals to a non-authorised party what routes do exist. To prevent it, show error page only to the users who has signed in

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/bookstore-example/74)
<!-- Reviewable:end -->
