### PR TITLE
chore: bump jetty maven plugin version to fix build in java21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>11.0.13</version>
+                <version>11.0.15</version>
                 <configuration>
                     <scan>2</scan>
                 </configuration>


### PR DESCRIPTION
Fixes: https://github.com/vaadin/flow/issues/19589

