### PR TITLE
fix: use Locale.of instead of constructors

### DIFF
--- a/src/main/java/org/vaadin/example/bookstore/ui/MainLayout.java
+++ b/src/main/java/org/vaadin/example/bookstore/ui/MainLayout.java
@@ -68,7 +68,7 @@ public class MainLayout extends AppLayout implements RouterLayout {
 
         // Add language selector
         top.add(new LanguageSwitcher(Locale.ENGLISH,
-                new Locale("fa","IR", "فارسی")));
+                new Locale.Builder().setLanguage("fa").setRegion("IR").setVariant("فارسی").build()));
 
         addToNavbar(top);
 

--- a/src/main/java/org/vaadin/example/bookstore/ui/login/LoginScreen.java
+++ b/src/main/java/org/vaadin/example/bookstore/ui/login/LoginScreen.java
@@ -73,7 +73,7 @@ public class LoginScreen extends FlexLayout {
         loginInformation.add(loginInfoText);
         loginInformation.add(
                 new LanguageSwitcher(Locale.ENGLISH,
-                        new Locale("fa","IR", "فارسی")));
+                        new Locale.Builder().setLanguage("fa").setRegion("IR").setVariant("فارسی").build()));
 
         return loginInformation;
     }


### PR DESCRIPTION
Instead of using Locale constructors
that are deprecated use Locale.of

Fixes #412

