### PR TITLE
Fix StaleElementReferenceException in MainLayoutElement on Windows

### DIFF
--- a/src/test/java/org/vaadin/example/MainLayoutElement.java
+++ b/src/test/java/org/vaadin/example/MainLayoutElement.java
@@ -16,7 +16,10 @@ public class MainLayoutElement extends AppLayoutElement {
             this.getDrawerToggle().click();
         }
 
-        waitUntil(driver ->"Inventory".equals(findElements(By.className("menu-link")).get(0).getText()));
+        waitUntil(driver -> {
+            List<WebElement> links = driver.findElements(By.className("menu-link"));
+            return !links.isEmpty() && "Inventory".equals(links.get(0).getText());
+        });
         final List<WebElement> elements = new ArrayList<>();
         elements.addAll(findElements(By.className("menu-link")));
         elements.addAll(findElements(By.className("menu-button")));


### PR DESCRIPTION
## Summary

`LoginScreenIT.loginAsAdmin_hasAdminViewLink` fails with `StaleElementReferenceException` on Windows when running against Vaadin 25.2.x. Passes on Linux and on Windows with 25.1.x.

Affects both `bookstore-example` and `bookstore-example:rtl-demo`.

### Root Cause

`MainLayoutElement.findMenuLinks()` uses `this` (the AppLayout DOM reference) inside a `waitUntil` lambda:

```java
waitUntil(driver -> "Inventory".equals(findElements(By.className("menu-link")).get(0).getText()));
```

With Spring Boot 4.x, the post-login redirect takes longer on Windows, so the AppLayout element is found mid-initialization. Vaadin replaces the DOM as initialization completes, making the captured `this` stale by the time `waitUntil` polls.

### Fix

Query from the driver root inside the lambda instead of relying on `this`:

```java
waitUntil(driver -> {
    List<WebElement> links = driver.findElements(By.className("menu-link"));
    return !links.isEmpty() && "Inventory".equals(links.get(0).getText());
});
```

This is safe because `menu-link` elements only exist inside the AppLayout navigation.

Closes #514